### PR TITLE
release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# ChangeLog
+
+### Unreleased
+
+
+### 1.0.0 - 2022-05-29
+
+- initial release

--- a/README.md
+++ b/README.md
@@ -19,42 +19,45 @@ git submodule add https://github.com/msimerson/.release
 
 This will:
 
-    - create a branch named release-vN.N.N
-    - bump the version number in package.json
-    - add an entry to CHANGE*.md with the version number and today's date
-    - open the file in your chosen markdown editor
+- create a branch named release-vN.N.N
+- bump the version number in package.json
+- add an entry to CHANGE*.md with the version number and today's date
+- open the file in your chosen markdown editor
 
 Notes:
 
-    - Your CHANGELOG file needs an entry like this: #### N.N.N
-        - New changelog entries are inserted after that market
-    - Opening the file in your editor requires `open`
+- Your CHANGELOG file needs an entry like this: ### Unreleased
+    - New changelog entries are inserted after that marker
+- Opening the file in your editor requires `open`
 
+----
 
 ### Push your release
 
 After editing your CHANGELOG and confirming all your changes:
 
-```js
+```sh
 .release/push.sh
 ```
 
 This will:
 
-    - commit package.json and CHANGELOG
     - push the changes to origin
     - create a Pull Request (if `gh` is installed)
+    - create a draft Release
+
+----
 
 ### Cleanup
 
 After your PR is merged, cleanup the feature branch with:
 
-```js
+```sh
 .release/cleanup.sh
 ```
 
 This will:
 
-    - switch to the master branch
-    - delete the feature branch
-    - pull changes from origin
+- switch to the main branch
+- delete the feature branch
+- pull changes from origin

--- a/base.sh
+++ b/base.sh
@@ -1,8 +1,21 @@
 #!/bin/sh
 
-branch_is_master()
+get_main_branch()
 {
-    if [ "$(git branch --show-current)" = "master" ]; then
+    MAIN_BRANCH="main"
+
+    if [ -z "$(git branch -l main)" ]; then
+        MAIN_BRANCH="master"
+    fi
+
+    export MAIN_BRANCH
+}
+
+branch_is_main()
+{
+    get_main_branch
+
+    if [ "$(git branch --show-current)" = "$MAIN_BRANCH" ]; then
         return 0
     fi
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 
+. .release/base.sh || exit
+
 CURRENT_BRANCH=$(git branch --show-current)
 
-if [ "$CURRENT_BRANCH" != "master" ];
+get_main_branch
+
+if [ "$CURRENT_BRANCH" != "$MAIN_BRANCH" ];
 then
-    git checkout master
+    git checkout "$MAIN_BRANCH"
     git branch -d "$CURRENT_BRANCH"
     git pull
 fi

--- a/do.sh
+++ b/do.sh
@@ -24,22 +24,52 @@ NEW_VERSION=$(npm --no-git-tag-version version "$1")
 YMD=$(date "+%Y-%m-%d")
 # echo "Preparing $NEW_VERSION - $YMD"
 
-if branch_is_master; then
+if branch_is_main; then
     git checkout -b "release-${NEW_VERSION}"
 fi
 
 update_changes() {
-    tee .release/new.txt <<EO_CHANGE
+    cat << EO_CHANGE >> .release/new.txt
 
 
-#### ${NEW_VERSION//v} - $YMD
+### [${NEW_VERSION//v}] - $YMD
 
--
--
+#### Added
+
+- 
+
+#### Fixed
+
+- 
+
+#### Changed
+
+- 
 EO_CHANGE
 
-    sed -i '' -e "/#### N.N.N.*$/r .release/new.txt" "$CHANGELOG"
+    LAST_TAG=$(git describe --tags --abbrev=0)
+    if [ "$LAST_TAG" != "" ]; then
+        # append log entries since the last tag (release)
+        git log --pretty=format:"- %s" "$LAST_TAG..HEAD" >> .release/new.txt
+    fi
+
+    echo "" >> .release/new.txt
+
+    # insert contents of new.txt into CHANGELOG.md after marker
+    if head "$CHANGELOG" | grep -q Unreleased;
+        sed -i '' -e "/### Unreleased$/r .release/new.txt" "$CHANGELOG"
+    then
+        sed -i '' -e "/#### N.N.N.*$/r .release/new.txt" "$CHANGELOG"
+    fi
     rm .release/new.txt
+
+    if tail "$CHANGELOG" | grep -q "$NEW_VERSION";
+    then
+        # the VERSION (added above) is a markdown [URL]. Add the
+        # release URL to the bottom of the file.
+        REPO_URL=$(gh repo view --json url -q ".url")
+        echo "[$NEW_VERSION]: $REPO_URL/releases/tag/$NEW_VERSION" >> "$CHANGELOG"
+    fi
 
     if command -v open; then open "$CHANGELOG"; fi
 
@@ -49,3 +79,7 @@ EO_CHANGE
 
 find_changelog
 update_changes
+
+git add package.json
+git add "$CHANGELOG"
+git commit -m "bump version to $NEW_VERSION"

--- a/push.sh
+++ b/push.sh
@@ -2,22 +2,26 @@
 
 . .release/base.sh || exit
 
-if branch_is_master; then
-    echo "ERROR: run the push script in a feature branch! (not master)"
+if branch_is_main; then
+    echo "ERROR: run the push script in a feature branch! (not main)"
     exit
 fi
 
-VERSION=$(node -e 'console.log(require("./package.json").version)')
+assure_repo_is_clean #|| exit
 
-find_changelog
+REL_BRANCH=$(git branch --show-current)
+PKG_VERSION=$(node -e 'console.log(require("./package.json").version)')
+LAST_TAG=$(git describe --tags --abbrev=0)
+REPO_URL=$(gh repo view --json url -q ".url")
+GIT_NOTES=$(git log --pretty=format:"- %s" "$LAST_TAG..HEAD")
+GIT_URL_NOTES=$(git log --pretty=format:"- [%h]($REPO_URL/commit/%h) %s" "$LAST_TAG..HEAD")
 
-git add package.json
-git add "$CHANGELOG"
-
-git commit -m "Release v$VERSION"
-
-git push --set-upstream origin "$(git branch --show-current)"
+git push --set-upstream origin "$REL_BRANCH"
 
 if command -v gh; then
-    gh pr create
+    gh pr create -d --title "Release v$PKG_VERSION" --body="$GIT_NOTES"
+
+    if [ "$LAST_TAG" != "" ]; then
+        gh release create -d "$PKG_VERSION" --target "$REL_BRANCH" --title "$PKG_VERSION" --notes "$GIT_URL_NOTES"
+    fi
 fi


### PR DESCRIPTION
more automation

- feat: permit main branch to be 'main', was 'master'
- feat: auto-insert commit messages since last tag into CHANGELOG
- feat: create PR automatically
- feat: create Release automatically
- doc(CHANGELOG.md): added
- doc(fix): code fences should be sh